### PR TITLE
fix 404 errors with local paths

### DIFF
--- a/client/src/public/.htaccess
+++ b/client/src/public/.htaccess
@@ -1,1 +1,7 @@
 AddType application/wasm .wasm
+
+RewriteEngine On
+
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteRule ^ index.html [L]


### PR DESCRIPTION
Up to now reloading a page with the initial URL https://winden.app/s lead to a 404 because there was no file served under that path.

As the paths are handled in the webapp we need to serve the main index.html in all cases.