### PR TITLE
Fix timeout issue for first tests execution

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,8 @@ jobs:
       - name: Run UNIT and INTEGRATION tests
         run: |
           docker compose --profile e2e up -d client-ci
+          # give some time load webapp
+          sleep 60
           docker compose --profile e2e run client-ci npm run test
 
       - name: Run END-2-END tests


### PR DESCRIPTION
Sometime we see issue, when first test fires, but web app is not yet fully loaded, even if docker container started.
On local machine there is no issue, however in github actions we see unit/integration test failures.

Added small sleep time to allow client-ci properly load up. 