### PR TITLE
Fix gulpfile script to use name prod

### DIFF
--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -112,7 +112,7 @@ const publicCopy = () =>
 const allowRobots = () =>
   gulp
     .src(['dist/robots.txt'])
-    .pipe(gulpif(process.env.ENVIRONMENT === "production" , replace('Disallow', 'Allow')))
+    .pipe(gulpif(process.env.ENVIRONMENT === "prod" , replace('Disallow', 'Allow')))
     .pipe(gulp.dest('dist'));
 
 const public = gulp.series(publicClean, publicCopy, allowRobots);


### PR DESCRIPTION
Fix gulpfile.js script to use name prod when deploying to production