### PR TITLE
Fix stage deployment env and increase actions version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,12 +27,12 @@ jobs:
       TEST_ENV: foobar
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
 
       - name: setup npm, yarn etc.
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
 
@@ -42,12 +42,27 @@ jobs:
           "https://github.com/docker/compose/releases/download/v2.6.1/docker-compose-linux-x86_64"
           sudo chmod +x /usr/local/bin/docker-compose
 
-      - name: create config
+      - name: create config for production env.
+        if: inputs.environment == 'prod'
         run: |
-          touch ./client-e2e/.env
+          touch ./client/.env
           cat <<EOF >> ./client/.env
           MAILBOX_URL="wss://mailbox.winden.app/v1"
           RELAY_URL="wss://relay.winden.app/"
+          SFTP_HOSTNAME=${{ secrets.SFTP_HOSTNAME }}
+          SFTP_USERNAME=${{ secrets.SFTP_USERNAME }}
+          SFTP_IDENTITY="${{ secrets.SFTP_IDENTITY }}"
+          NODE_ENV=production
+          ENVIRONMENT=${{ inputs.environment }}
+          EOF
+
+      - name: create config for stage env.
+        if: inputs.environment == 'stage'
+        run: |
+          touch ./client/.env
+          cat <<EOF >> ./client/.env
+          MAILBOX_URL="wss://mailbox.stage.winden.app/v1"
+          RELAY_URL="wss://relay.stage.winden.app/"
           SFTP_HOSTNAME=${{ secrets.SFTP_HOSTNAME }}
           SFTP_USERNAME=${{ secrets.SFTP_USERNAME }}
           SFTP_IDENTITY="${{ secrets.SFTP_IDENTITY }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,19 +42,19 @@ jobs:
           "https://github.com/docker/compose/releases/download/v2.6.1/docker-compose-linux-x86_64"
           sudo chmod +x /usr/local/bin/docker-compose
 
-      - name: create config for production env.
+      - name: create variables for production env.
         if: inputs.environment == 'prod'
         run: |
           echo "MAILBOX_URL=wss://mailbox.winden.app/v1" >> $GITHUB_ENV
           echo "RELAY_URL=wss://relay.winden.app/" >> $GITHUB_ENV
 
-      - name: create config for stage env.
+      - name: create variables for stage env.
         if: inputs.environment == 'stage'
         run: |
           echo "MAILBOX_URL=wss://mailbox.stage.winden.app/v1" >> $GITHUB_ENV
           echo "RELAY_URL=wss://relay.stage.winden.app/" >> $GITHUB_ENV
 
-      - name: create config for stage env.
+      - name: create config .env file
         if: inputs.environment == 'stage'
         run: |
           touch ./client/.env


### PR DESCRIPTION
Now stage.winden.app deploys with production env. of mailbox and relay server. 
Stage.winden.app should use stage mailbox/relay services.

Additionally increase github action version to avoid warning message: Node.js 12 actions are deprecated