### PR TITLE
Avoid duplicate and useless checks

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,3 +1,4 @@
+---
 # For most projects, this workflow file will not need changing; you simply need
 # to commit it to your repository.
 #
@@ -21,8 +22,24 @@ on:
     - cron: '26 13 * * 5'
 
 jobs:
+  pre:
+    # Verification to be done before the real check
+    name: Pre-check
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_flag.outputs.should_skip }}
+    steps:
+      - name: Skip flag
+        id: skip_flag
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          concurrent_skipping: 'same_content_newer'
+          paths: '["client/**", "client-e2e/**", ".github/workflows/code-analysis.yml"]'
+
   analyze:
     name: Analyze
+    needs: pre
+    if: needs.pre.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,5 @@
 ---
-name: deployment
+name: Deployment
 
 on:
   workflow_dispatch:
@@ -21,7 +21,7 @@ jobs:
     # `if` required because a workflow run is triggered regardless of
     # the result of the previous workflow (see the documentation page)
 #    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-
+    name: Deploy
     runs-on: ubuntu-22.04
     env:
       TEST_ENV: foobar

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -19,7 +19,7 @@ jobs:
         uses: fkirc/skip-duplicate-actions@v5
         with:
           concurrent_skipping: 'same_content_newer'
-          paths: '["client/**", "client-e2e/**", ".github/workflows/main.yml"]'
+          paths: '["client/**", "client-e2e/**", ".github/workflows/integrate.yml"]'
 
   build:
     name: Build/Test

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -1,4 +1,5 @@
-name: Build and Test (CI)
+---
+name: Integration
 
 on:
   push:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,14 +2,27 @@ name: Build and Test (CI)
 
 on:
   push:
-    branches:
-    - main
   pull_request:
   workflow_dispatch:
 
 jobs:
+  pre:
+    # Verification to be done before the real check
+    name: Pre-check
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_flag.outputs.should_skip }}
+    steps:
+      - name: Skip flag
+        id: skip_flag
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          concurrent_skipping: 'same_content_newer'
+
   build:
     name: Build/Test
+    needs: pre
+    if: needs.pre.outputs.should_skip != 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,12 @@
 name: Build and Test (CI)
-on: [push, pull_request]
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+  workflow_dispatch:
+
 jobs:
   build:
     name: Build/Test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,7 @@ jobs:
         uses: fkirc/skip-duplicate-actions@v5
         with:
           concurrent_skipping: 'same_content_newer'
+          paths: '["client/**", "client-e2e/**", ".github/workflows/main.yml"]'
 
   build:
     name: Build/Test


### PR DESCRIPTION
As described in #94, we  may want to avoid the integration test to run twice upon pull_request.

This PR introduce a pre-check to avoid duplicate test to be run on the same content.
In addition, this PR also provides:
- a manual trigger to test any branch w/o having to create a PR.
- a similar pre-check to skip code analysis based on the same criteria
- new file, workflow and job names to improve clarity 

---

## Code Review Checklist (to be filled out by reviewer)

- [ ] Description accurately reflects what changes are being made.
- [ ] Description explains why the changes are being made (or references an issue containing one).
- [ ] The PR appropriately sized.
- [ ] New code has enough tests. 
- [ ] New code has enough documentation to answer "how do I use it?" and "what does it do?".
- [ ] Existing documentation is up-to-date, if impacted.
