### PR TITLE
Deployment env fix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,6 +67,7 @@ jobs:
           NODE_ENV=production
           ENVIRONMENT=${{ inputs.environment }}
           EOF
+          touch ./client-e2e/.env
 
       - name: prepare
         run: |

--- a/client/.prettierignore
+++ b/client/.prettierignore
@@ -2,3 +2,4 @@ dist
 node_modules
 src/public
 vendor
+wasm_exec.js


### PR DESCRIPTION
Fixing stage deployment issue on CI
https://github.com/LeastAuthority/winden/actions/runs/3711559359

```
Run docker-compose build
open /home/runner/work/winden/winden/client-e2e/.env: no such file or directory
```

Seems docker compose checks all env_file if they exists, even if that specific container will not be built.

