### PR TITLE
Fix E2E tests execution

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -79,7 +79,6 @@ jobs:
           docker compose --profile e2e run client-ci npm run test -- --coverage
 
       - name: Run END-2-END tests
-        if: ${{ github.event_name == 'pull_request' }}
         run: |
           docker compose --profile e2e run --rm client-e2e 
 

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "winden",
   "private": true,
-  "version": "0.5.3-beta",
+  "version": "0.5.4-beta",
   "scripts": {
     "test": "jest",
     "storybook": "start-storybook -p 6006",


### PR DESCRIPTION
It seems that after adding duplicity run check for CI, it ignored executing CI process for pull_request, where running E2E tests supposed to run.

Case visible here:
https://github.com/LeastAuthority/winden/actions/runs/3956222108/jobs/6775222052

I have enabled always run E2E that we would not get in such situation, when some steps are skipped.

FYI. @btlogy 