### PR TITLE
Change Link wrapper component to use react-router-dom's Link

### DIFF
--- a/client/src/app/components/Link.tsx
+++ b/client/src/app/components/Link.tsx
@@ -16,7 +16,7 @@ export default function Link(
   const navigate = useNavigate();
 
   return (
-    <a
+    <UnwrappedLink
       {...props}
       onClick={(e) => {
         e.preventDefault();


### PR DESCRIPTION
Seems there was a mistake in the `Link` component. Links should render `<a href="">` and not `<a to="">`.