### PR TITLE
Change CI to wait for client to build before running tests

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -76,8 +76,8 @@ jobs:
       - name: Run UNIT and INTEGRATION tests
         run: |
           docker compose --profile e2e up -d client
-          # give some time load webapp
-          sleep 60
+          # wait for webpack to compile app before running tests
+          { docker compose logs -f --tail 0 client & echo $! > pid; } | { grep -P -m1 "webpack .+ compiled successfully" && kill -9 $(cat pid) && rm pid; }
           docker compose --profile e2e run client npm run test -- --coverage
 
       - name: Run END-2-END tests


### PR DESCRIPTION
Currently the CI starts the docker services, wait 60 seconds, then run the tests. We wait because the winden client isn't available until webpack finishes building the app. The problem is that if the build takes longer than 60 seconds the ci will fail, and if it takes less than 60 seconds then it's time wasted. Instead, we should wait until webpack compiles.