### PR TITLE
Add receiver connection status indicator

### DIFF
--- a/client/src/app/components/screens/send/SendInstructionsScreen.tsx
+++ b/client/src/app/components/screens/send/SendInstructionsScreen.tsx
@@ -1,4 +1,11 @@
-import { Button, createStyles, Group, Stack, Text } from "@mantine/core";
+import {
+  Button,
+  createStyles,
+  Group,
+  Loader,
+  Stack,
+  Text,
+} from "@mantine/core";
 import { useClipboard, useViewportSize } from "@mantine/hooks";
 import React from "react";
 import { Files, X } from "tabler-icons-react";
@@ -6,6 +13,7 @@ import { useAppDispatch, useAppSelector } from "../../../hooks/redux";
 import { useCommonStyles } from "../../../hooks/useCommonStyles";
 import {
   requestCancelTransfer,
+  selectIsPeerConnected,
   selectWormholeCode,
 } from "../../../wormholeSlice";
 import Content from "../../Content";
@@ -13,6 +21,7 @@ import FileLabel from "../../FileLabel";
 
 type ContentProps = {
   code: string;
+  isPeerConnected: boolean;
   copied: boolean;
   onCopy: () => void;
   onCancel: () => void;
@@ -90,6 +99,20 @@ export function SendInstructionsScreenContent(props: ContentProps) {
             {props.copied ? "Link copied!" : "Copy link"}
           </Button>
         </Group>
+        <Group spacing="xs">
+          <Loader size={14.4} />
+          <Text
+            component="p"
+            size={14.4}
+            weight={400}
+            color="dark-grey"
+            align="center"
+          >
+            {props.isPeerConnected
+              ? "Receiver connected. Waiting for receiver to start transfer..."
+              : "Waiting for receiver to connect..."}
+          </Text>
+        </Group>
         <Button
           leftIcon={<X />}
           data-testid="send-page-cancel-button"
@@ -108,11 +131,13 @@ type Props = {};
 export default function SendInstructionsScreen({}: Props) {
   const clipboard = useClipboard({ timeout: 2000 });
   const wormholeCode = useAppSelector(selectWormholeCode);
+  const isPeerConnected = useAppSelector(selectIsPeerConnected);
   const dispatch = useAppDispatch();
 
   return wormholeCode ? (
     <SendInstructionsScreenContent
       code={wormholeCode}
+      isPeerConnected={isPeerConnected}
       copied={clipboard.copied}
       onCopy={() =>
         clipboard.copy(

--- a/client/src/app/wormholeSlice.ts
+++ b/client/src/app/wormholeSlice.ts
@@ -29,6 +29,7 @@ type WormholeState =
       file: FileInfo;
       code: string;
       startedAt: null;
+      isPeerConnected: boolean;
     }
   | {
       status: "consenting";
@@ -65,6 +66,10 @@ export const setFileAndCode = createAction<
   { file: FileInfo; code: string },
   "wormhole/setFileAndCode"
 >("wormhole/setFileAndCode");
+export const setIsPeerConnected = createAction<
+  void,
+  "wormhole/setIsPeerConnected"
+>("wormhole/setIsPeerConnected");
 export const answerConsent = createAction<boolean, "wormhole/answerConsent">(
   "wormhole/answerConsent"
 );
@@ -117,6 +122,15 @@ export const wormholeSlice = createSlice<
             file: action.payload.file,
             code: action.payload.code,
             startedAt: null,
+            isPeerConnected: false,
+          };
+        }
+      })
+      .addCase(setIsPeerConnected, (state) => {
+        if (state.status === "waiting") {
+          return {
+            ...state,
+            isPeerConnected: true,
           };
         }
       })
@@ -193,6 +207,8 @@ export const selectIsWormholeLoaded = (state: RootState) =>
 export const selectWormholeStatus = (state: RootState) => state.wormhole.status;
 export const selectWormholeCode = (state: RootState) =>
   state.wormhole.status === "waiting" ? state.wormhole.code : null;
+export const selectIsPeerConnected = (state: RootState) =>
+  state.wormhole.status === "waiting" ? state.wormhole.isPeerConnected : false;
 export const selectTransferProgressPercent = (state: RootState) =>
   state.wormhole.status === "transferring"
     ? Math.round((state.wormhole.sentBytes / state.wormhole.totalBytes) * 100)

--- a/client/wasm/src/lib.rs
+++ b/client/wasm/src/lib.rs
@@ -156,6 +156,13 @@ pub async fn upload_file(
 
     let wormhole = f.await?;
 
+    if let Ok(on_peer_connected_func) = js_sys::Reflect::get(&opts, &"on_peer_connected".into()) {
+        let on_peer_connected_func = js_sys::Function::from(on_peer_connected_func);
+        on_peer_connected_func
+            .call0(&JsValue::UNDEFINED)
+            .expect("Failed to call on_peer_connected");
+    }
+
     let file_name = send_result.file.name();
     let file_size = send_result.file.size() as u64;
     let mut file_wrapper = FileWrapper::new(send_result.file);


### PR DESCRIPTION
Ref: https://github.com/LeastAuthority/winden/issues/107

Before the receiver connects: (has message `Waiting for receiver to connect...`)

![Screen Shot 2023-03-09 at 09 31 07](https://user-images.githubusercontent.com/7854367/223892855-9fb6e0b8-c0d1-4b24-922e-838787470e20.png)

After the receiver connects: (has message `Receiver connected. Waiting for receiver to start transfer...`)

![Screen Shot 2023-03-09 at 09 31 21](https://user-images.githubusercontent.com/7854367/223892860-dc6d86cb-8be6-4176-99b7-458aefff0872.png)

