### PR TITLE
Add wasm-pack install to client image

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -6,6 +6,7 @@ RUN apk add git openssh lftp curl rust
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
+RUN curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
 RUN npm -g config set user root
 RUN npm install --global gulp-cli


### PR DESCRIPTION
Sometimes wasm-pack won't install on first build, which prevents the wasm module from being built. Adding wasm-pack to the dockerfile fixes this