### PR TITLE
Fix permissions for npm scripts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: prepare
         run: |
-          docker-compose build
+          docker-compose build --build-arg uid="$(id -u)" --build-arg gid="$(id -g)"
           docker-compose run client npm i
 
       - name: deploy

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Set up containers
         run: |
-          docker compose -f docker-compose.yml -f docker-compose.e2e.yml --profile e2e build
+          docker compose -f docker-compose.yml -f docker-compose.e2e.yml --profile e2e build --build-arg uid="$(id -u)" --build-arg gid="$(id -g)"
           docker compose run --rm client npm i
           docker compose run --rm client ./scripts/setup.sh
           docker compose -f docker-compose.yml -f docker-compose.e2e.yml --profile e2e run --rm client-e2e npm i

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -70,14 +70,12 @@ jobs:
           printf "Client-e2e .env:\n"
           cat ./.env
 
-      - name: Setup docker images
-        run: docker compose -f docker-compose.yml -f docker-compose.e2e.yml --profile e2e build
-
       - name: Set up containers
         run: |
+          docker compose -f docker-compose.yml -f docker-compose.e2e.yml --profile e2e build
           docker compose run --rm client npm i
           docker compose run --rm client ./scripts/setup.sh
-          docker-compose -f docker-compose.yml -f docker-compose.e2e.yml --profile e2e run --rm client-e2e npm i
+          docker compose -f docker-compose.yml -f docker-compose.e2e.yml --profile e2e run --rm client-e2e npm i
 
       - name: Start up devserver
         run: |

--- a/client-e2e/Dockerfile
+++ b/client-e2e/Dockerfile
@@ -1,8 +1,10 @@
 FROM node:16-alpine
 
+# Switch to the existing node user instead of root
+USER node
+
 # Switch to the directory where the client code will live
 WORKDIR /usr/src/app/client-e2e
-
 
 # Install the required packages... But not really?
 # FIXME: do it or get rid of this block

--- a/client-e2e/Dockerfile
+++ b/client-e2e/Dockerfile
@@ -1,7 +1,24 @@
 FROM node:16-alpine
 
-# Switch to the existing node user instead of root
-USER node
+# Parameters for default user:group
+ARG uid=1000
+ARG user=appuser
+ARG gid=1000
+ARG group=appgroup
+
+# Remove exising node user to avoid possible conflict
+RUN deluser node && rm -rf /home/node && chown -R root:root /opt
+
+# Add user and group for build and runtime
+RUN addgroup -g "${gid}" "${group}" && adduser -D -h /home/${user} -s /bin/bash -G "${group}" -u "${uid}" "${user}"
+
+# Prepare directories
+RUN DIRS="/usr/src/app" && \
+    mkdir -p ${DIRS} && \
+    chown -R ${user}:${group} $DIRS
+
+# Switch to non-root user
+USER ${user}
 
 # Switch to the directory where the client code will live
 WORKDIR /usr/src/app/client-e2e

--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -1,2 +1,4 @@
 dist/
 node_modules/
+pkg/
+wasm/target/

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,40 +1,46 @@
 FROM node:16-alpine
 
-# Switch to the directory where the client code will live
-WORKDIR /usr/src/app/client
-
 # Install some require system packages
 RUN apk add git openssh openssl lftp curl rust bash
+
+# Switch to the existing node user instead of root
+USER node
 
 # Install latest rust on top of it
 # FIXME: make it reproducible!
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-ENV PATH="/root/.cargo/bin:${PATH}"
+ENV PATH="/home/node/.cargo/bin:${PATH}"
 
 # Install wasm-pack to build the WebAssembly packages
 # FIXME: make it reproducible!
 RUN curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
-# Workaround permission issues
-RUN npm -g config set user root
+# Switch to the parent directory of where the client code will live
+# So the modules installed here will be found by the module resolution
+# See https://nodejs.org/api/modules.html#all-together
+WORKDIR /usr/src/app
 
-# Install the sentry node package globaly
-RUN npm install --location=global @sentry/cli
+RUN npm install @sentry/cli && \
+    npm cache clean --force 2> /dev/null
 ENV SENTRYCLI_SKIP_DOWNLOAD=1
 ARG SENTRYCLI_USE_LOCAL=1
 
 # Install the required packages globaly and unsafely
 COPY package.json .
 COPY package-lock.json .
-RUN npm install --location=global --unsafe-perm
+RUN npm clean-install && \
+    npm cache clean --force 2> /dev/null
+
+# Add paths to node modules installed above
+ENV PATH=/usr/src/app/node_modules/.bin:$PATH
+
+# Switch to the directory where the client code will live
+WORKDIR /usr/src/app/client
 
 # Copy the whole context except what is explicitly ignored
 # TODO: be explicit instead?
 COPY . .
 
-# Install the required pages again, but localy this time
-RUN npm install
-
 # Start the dev server by default
-CMD ["./node_modules/.bin/ts-node", "./scripts/devserver.ts"]
+CMD ["npm", "run", "serve"]
 EXPOSE 8080

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -3,13 +3,30 @@ FROM node:16-alpine
 # Install some require system packages
 RUN apk add git openssh openssl lftp curl rust bash
 
-# Switch to the existing node user instead of root
-USER node
+# Parameters for default user:group
+ARG uid=1000
+ARG user=appuser
+ARG gid=1000
+ARG group=appgroup
+
+# Remove exising node user to avoid possible conflict
+RUN deluser node && rm -rf /home/node && chown -R root:root /opt
+
+# Add user and group for build and runtime
+RUN addgroup -g "${gid}" "${group}" && adduser -D -h /home/${user} -s /bin/bash -G "${group}" -u "${uid}" "${user}"
+
+# Prepare directories
+RUN DIRS="/usr/src/app" && \
+    mkdir -p ${DIRS} && \
+    chown -R ${user}:${group} $DIRS
+
+# Switch to non-root user
+USER ${user}
 
 # Install latest rust on top of it
 # FIXME: make it reproducible!
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-ENV PATH="/home/node/.cargo/bin:${PATH}"
+ENV PATH="/home/${user}/.cargo/bin:${PATH}"
 
 # Install wasm-pack to build the WebAssembly packages
 # FIXME: make it reproducible!

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,7 @@ services:
       - 5900:5900
       - 7900:7900
     build:
+      context: .
       dockerfile: ./client-e2e/images/Dockerfile.chrome
     shm_size: 2gb
     depends_on:
@@ -76,6 +77,7 @@ services:
       - 5901:5900
       - 7901:7900
     build:
+      context: .
       dockerfile: ./client-e2e/images/Dockerfile.edge
     shm_size: 2gb
     depends_on:
@@ -96,6 +98,7 @@ services:
       - 5902:5900
       - 7902:7900
     build:
+      context: .
       dockerfile: ./client-e2e/images/Dockerfile.firefox
     shm_size: 2gb
     depends_on:


### PR DESCRIPTION
Part of #171 

This PR should fix the permissions which were occurring because `npm` runs as `node` user regardless if anything else in the container runs as `root`!
The best option is to simply avoid the `root` as a best practice too.

But using a specific `user`/`uid` + `group`/`gid` usually requires some precautions as the current `uid` is not always `1000` (e.g.: GitHub runner).
The changes covers this with some `build-arg` which can be used to tune the `uid` and `gid` inside the image if needed (e.g.: GitHub workflows).

This PR also proposes a way to install the node modules in the parent directory where the [module resolution](https://nodejs.org/api/modules.html#all-together) mechanism will lookup up if they are not found in the current one (if the image is run alone).
Although, the whole idea to `npm install` the modules twice for the `client` image (once inside and once outside), but only once  for the `client-e2e` one (outside) is questionable and should be improved separately (see related issue).
