### PR TITLE
Use multi-stage to build a smaller client image

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,12 +1,14 @@
 # Start from the official Rust image
-FROM rust:1.75.0-alpine3.18@sha256:d4d3ccbfb49d4119c748144b2767966a8a3361ee9c529e8fcfa1fa9adfbc9cf5 as builder
+FROM rust:1.71.1-alpine3.18@sha256:3419c5212b75ce4e7786b71bd2bd49587a2481f8b42ca685d719d265a11c7e96 as builder
 
 # Install component 'rust-std' for 'wasm32-unknown-unknown'
+# FIXME: validate downloaded content with checksum
 RUN wget -q -O - https://static.rust-lang.org/dist/rust-std-${RUST_VERSION}-wasm32-unknown-unknown.tar.gz \
     | gunzip | tar -x --strip-components 4 -C /usr/local/rustup/toolchains/${RUST_VERSION}-x86_64-unknown-linux-musl/lib/rustlib \
     rust-std-${RUST_VERSION}-wasm32-unknown-unknown/rust-std-wasm32-unknown-unknown/lib/rustlib/wasm32-unknown-unknown
 
 # Install wasm-pack to build the WebAssembly package
+# FIXME: validate downloaded content with checksum
 RUN WASM_PACK_VERSION=0.12.1 \
     && wget -q -O - https://github.com/rustwasm/wasm-pack/releases/download/v${WASM_PACK_VERSION}/wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl.tar.gz \
     | gunzip | tar -x --strip-components 1 -C /usr/local/cargo/bin \

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,7 +1,22 @@
-FROM node:16-alpine
+# Start from the official Rust image
+FROM rust:1.75.0-alpine3.18@sha256:d4d3ccbfb49d4119c748144b2767966a8a3361ee9c529e8fcfa1fa9adfbc9cf5 as builder
+
+# Install component 'rust-std' for 'wasm32-unknown-unknown'
+RUN wget -q -O - https://static.rust-lang.org/dist/rust-std-${RUST_VERSION}-wasm32-unknown-unknown.tar.gz \
+    | gunzip | tar -x --strip-components 4 -C /usr/local/rustup/toolchains/${RUST_VERSION}-x86_64-unknown-linux-musl/lib/rustlib \
+    rust-std-${RUST_VERSION}-wasm32-unknown-unknown/rust-std-wasm32-unknown-unknown/lib/rustlib/wasm32-unknown-unknown
+
+# Install wasm-pack to build the WebAssembly package
+RUN WASM_PACK_VERSION=0.12.1 \
+    && wget -q -O - https://github.com/rustwasm/wasm-pack/releases/download/v${WASM_PACK_VERSION}/wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl.tar.gz \
+    | gunzip | tar -x --strip-components 1 -C /usr/local/cargo/bin \
+    wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl/wasm-pack
+
+# Switch to the official NodeJS image
+FROM node:16-alpine3.18@sha256:a1f9d027912b58a7c75be7716c97cfbc6d3099f3a97ed84aa490be9dee20e787
 
 # Install some require system packages
-RUN apk add git openssh openssl lftp curl rust bash
+RUN apk add git openssh openssl lftp curl bash
 
 # Parameters for default user:group
 ARG uid=1000
@@ -20,18 +35,14 @@ RUN DIRS="/usr/src/app" && \
     mkdir -p ${DIRS} && \
     chown -R ${user}:${group} $DIRS
 
+# Copy the rust toolchain from the builder stage
+COPY --chown=${user}:${group} --from=builder /usr/local/rustup /home/${user}/.rustup
+ENV RUSTUP_HOME=/home/${user}/.rustup
+
+# Copy the wasm-pack from the builder stage
+COPY --chown=${user}:${group} --from=builder /usr/local/cargo /home/${user}/.cargo
+ENV CARGO_HOME=/home/${user}/.cargo
+ENV PATH="${CARGO_HOME}/bin:${PATH}"
+
 # Switch to non-root user
 USER ${user}
-
-# Install the rust toolchain
-WORKDIR /home/${user}
-RUN curl --proto '=https' --tlsv1.2 -sSf --output rustup-init \
-    https://static.rust-lang.org/rustup/archive/1.26.0/x86_64-unknown-linux-musl/rustup-init \
-    && chmod +x rustup-init \
-    && ./rustup-init -y --profile minimal \
-    && rm -f rustup-init
-ENV PATH="/home/${user}/.cargo/bin:${PATH}"
-
-# Install wasm-pack to build the WebAssembly packages
-RUN cargo install --version 0.12.1 wasm-pack \
-    && rm -rf /home/${user}/.cargo/registry

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,5 +1,5 @@
 # Start from the official Rust image
-FROM rust:1.71.1-alpine3.18@sha256:3419c5212b75ce4e7786b71bd2bd49587a2481f8b42ca685d719d265a11c7e96 as builder
+FROM rust:1.75.0-alpine3.18@sha256:d4d3ccbfb49d4119c748144b2767966a8a3361ee9c529e8fcfa1fa9adfbc9cf5 as builder
 
 # Install component 'rust-std' for 'wasm32-unknown-unknown'
 # FIXME: validate downloaded content with checksum
@@ -18,7 +18,7 @@ RUN WASM_PACK_VERSION=0.12.1 \
 FROM node:16-alpine3.18@sha256:a1f9d027912b58a7c75be7716c97cfbc6d3099f3a97ed84aa490be9dee20e787
 
 # Install some require system packages
-RUN apk add git openssh openssl lftp curl bash
+RUN apk add git openssh openssl lftp curl gcc musl-dev bash
 
 # Parameters for default user:group
 ARG uid=1000


### PR DESCRIPTION
Part of #177

I'm not super happy with the approach, but the image uses a more recent rust(up) setup and is twice smaller (from >2GB to +/ 1GB).
In addition, I've managed to pin the dependencies even more (next step: validate them with sha256).