### PR TITLE
Avoid clean-install to deploy with development env!

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,13 +66,11 @@ jobs:
           CLIENT=0 || CLIENT=1
           # Build image if client is missing
           test $CLIENT -eq 0 || \
-            docker compose --progress plain -f docker-compose.yml -f docker-compose.e2e.yml --profile e2e \
-            build --build-arg uid=$(id -u) --build-arg gid=${_GID} client
+            docker compose --progress plain build --build-arg uid=$(id -u) --build-arg gid=${_GID} client
 
       - name: Prepare containers
         run: |
-          docker compose build --build-arg uid="$(id -u)" --build-arg gid="$(id -g)" client
-          docker compose run --no-deps -e CI=true client npm clean-install
+          docker compose run --rm --no-deps -e CI=true client npm install
 
       - name: Deploy package
         run: docker compose run --no-deps client npm run deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
           SFTP_HOSTNAME=${{ secrets.SFTP_HOSTNAME }}
           SFTP_USERNAME=${{ secrets.SFTP_USERNAME }}
           SFTP_IDENTITY="${{ secrets.SFTP_IDENTITY }}"
-          NODE_ENV=production
+          NODE_ENV=development
           ENVIRONMENT=${{ inputs.environment }}
           EOF
           touch ./client-e2e/.env
@@ -70,7 +70,7 @@ jobs:
 
       - name: Prepare containers
         run: |
-          docker compose run --rm --no-deps -e CI=true client npm install
+          docker compose run --rm --no-deps -e CI=true client npm clean-install
 
       - name: Deploy package
         run: docker compose run --no-deps client npm run deploy


### PR DESCRIPTION
Part of #177 

It seems like we need a development environment to deploy the package!

It's because of those lines in the `package.json`:

```
{
  "name": "winden",
  "private": true,
  "version": "0.5.4-beta",
  "scripts": {
    ...
    "deploy": "ts-node ./scripts/build.ts --deploy",
  ...
  "devDependencies": {
    ...
    "ts-node": "^10.7.0",
```

And since a few PRs, the node modules installed are really matching the production environment, and it is no longer sufficient to deploy!

This PR re-established the previous situation.
We should find a better way to deploy w/o `ts-node`?